### PR TITLE
Henryiii/experimental/setuptools621

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -1,3 +1,6 @@
+import os
+from pathlib import Path
+
 import nox
 
 nox.options.sessions = ["lint", "tests", "tests_packaging"]
@@ -88,6 +91,22 @@ def build(session: nox.Session) -> None:
     session.log("Building normal files")
     session.run("python", "-m", "build", *session.posargs)
     session.log("Building pybind11-global files (PYBIND11_GLOBAL_SDIST=1)")
-    session.run(
-        "python", "-m", "build", *session.posargs, env={"PYBIND11_GLOBAL_SDIST": "1"}
-    )
+
+    # Temporarily change the project name (static project metadata)
+    pyproject = Path("pyproject.toml")
+    config = pyproject.read_text("utf-8")
+    global_config = config.replace('name = "pybind11"', 'name = "pybind11_global"')
+    os.rename("pyproject.toml", ".pyproject.orig")
+    pyproject.write_text(global_config, "utf-8")
+
+    try:
+        session.run(
+            "python",
+            "-m",
+            "build",
+            *session.posargs,
+            env={"PYBIND11_GLOBAL_SDIST": "1"}
+        )
+    finally:
+        pyproject.unlink()
+        os.rename(".pyproject.orig", "pyproject.toml")

--- a/tests/extra_python_package/test_files.py
+++ b/tests/extra_python_package/test_files.py
@@ -5,6 +5,8 @@ import subprocess
 import sys
 import tarfile
 import zipfile
+from contextlib import contextmanager
+from pathlib import Path
 
 # These tests must be run explicitly
 # They require CMake 3.15+ (--install)
@@ -108,19 +110,20 @@ def test_build_sdist(monkeypatch, tmpdir):
     out = subprocess.check_output(
         [
             sys.executable,
-            "setup.py",
-            "sdist",
-            "--formats=tar",
-            "--dist-dir",
+            "-m",
+            "build",
+            "--sdist",
+            "--outdir",
             str(tmpdir),
         ]
     )
     if hasattr(out, "decode"):
         out = out.decode()
 
-    (sdist,) = tmpdir.visit("*.tar")
+    print(out)
+    (sdist,) = tmpdir.visit("*.tar.gz")
 
-    with tarfile.open(str(sdist)) as tar:
+    with tarfile.open(str(sdist), "r:gz") as tar:
         start = tar.getnames()[0] + "/"
         version = start[9:-1]
         simpler = {n.split("/", 1)[-1] for n in tar.getnames()[1:]}
@@ -165,27 +168,48 @@ def test_build_sdist(monkeypatch, tmpdir):
     assert pyproject_toml == contents
 
 
+@contextmanager
+def global_package(monkeypatch):
+    pyproject = Path("pyproject.toml")
+    config = pyproject.read_text("utf-8")
+    config = config.replace('name = "pybind11"', 'name = "pybind11_global"')
+    assert 'name = "pybind11_global"' in config
+
+    os.rename("pyproject.toml", ".pyproject.orig")
+    pyproject.write_text(config, "utf-8")
+
+    try:
+        with monkeypatch.context() as m:
+            m.setenv("PYBIND11_GLOBAL_SDIST", "1")
+            yield
+    finally:
+        pyproject.unlink()
+        os.rename(".pyproject.orig", "pyproject.toml")
+
+
 def test_build_global_dist(monkeypatch, tmpdir):
 
     monkeypatch.chdir(MAIN_DIR)
-    monkeypatch.setenv("PYBIND11_GLOBAL_SDIST", "1")
 
-    out = subprocess.check_output(
-        [
-            sys.executable,
-            "setup.py",
-            "sdist",
-            "--formats=tar",
-            "--dist-dir",
-            str(tmpdir),
-        ]
-    )
+    with global_package(monkeypatch):
+        out = subprocess.check_output(
+            [
+                sys.executable,
+                "-m",
+                "build",
+                "--sdist",
+                "--outdir",
+                str(tmpdir),
+            ]
+        )
+
     if hasattr(out, "decode"):
         out = out.decode()
+    print(out)
 
-    (sdist,) = tmpdir.visit("*.tar")
+    (sdist,) = tmpdir.visit("*.tar.gz")
 
-    with tarfile.open(str(sdist)) as tar:
+    with tarfile.open(str(sdist), "r:gz") as tar:
         start = tar.getnames()[0] + "/"
         version = start[16:-1]
         simpler = {n.split("/", 1)[-1] for n in tar.getnames()[1:]}

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -6,3 +6,4 @@ pytest==7.0.0
 pytest-timeout
 scipy==1.5.4; platform_python_implementation!="PyPy" and python_version<"3.10"
 scipy==1.8.0; platform_python_implementation!="PyPy" and python_version=="3.10"
+build==0.7.0


### PR DESCRIPTION
Hello @henryiii, I did some changes in my PRs to setuptools as previously discussed. I believe now we can try again to add project metadata to `pyproject.toml`.

I tried to run `nox -s build` locally and it seems to pass!

Sorry for the confusing branch name (`add-some-type-hints`), one of other maintainers asked me to split up the massive PR in a sequence of smaller ones (which is very fair 😅). Since all these PRs are stacked, the last PR is the one that gets all the code and therefore can be used in builds... In my case the last PR is on the `add-some-type-hints` branch.