### PR TITLE
Henryiii/experimental/setuptools621

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -47,7 +47,7 @@ def tests_packaging(session: nox.Session) -> None:
     """
 
     session.install("-r", "tests/requirements.txt", "--prefer-binary")
-    session.run("pytest", "tests/extra_python_package")
+    session.run("pytest", "tests/extra_python_package", *session.posargs)
 
 
 @nox.session(reuse_venv=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools @ git+https://github.com/pypa/setuptools@add-some-type-hints",
+    "setuptools @ git+https://github.com/pypa/setuptools@experimental/support-pyproject",
     "cmake>=3.18",
     "ninja"
 ]

--- a/tests/extra_python_package/test_files.py
+++ b/tests/extra_python_package/test_files.py
@@ -271,11 +271,11 @@ def tests_build_wheel(monkeypatch, tmpdir):
 
 def tests_build_global_wheel(monkeypatch, tmpdir):
     monkeypatch.chdir(MAIN_DIR)
-    monkeypatch.setenv("PYBIND11_GLOBAL_SDIST", "1")
 
-    subprocess.check_output(
-        [sys.executable, "-m", "pip", "wheel", ".", "-w", str(tmpdir)]
-    )
+    with global_package(monkeypatch):
+        subprocess.check_output(
+            [sys.executable, "-m", "pip", "wheel", ".", "-w", str(tmpdir)]
+        )
 
     (wheel,) = tmpdir.visit("*.whl")
 


### PR DESCRIPTION
## Description

This is a follow-up experiment to make sure the experimental auto-discovery in setuptools don't break things for pybind.

## Changes

- Updated the git URL for the experimental branch in setuptools
- Added the `global_package` context manager for the `tests_build_global_wheel` to make sure global package is built correctly
